### PR TITLE
add eth-rpc subsection

### DIFF
--- a/whitepaper.tex
+++ b/whitepaper.tex
@@ -713,25 +713,24 @@ Processes that serve sensitive HTTP APIs for user interfaces are encouraged to u
 
 \subsubsection{ETH RPC}
 \label{sec:oseth}
-The OS includes an Ethereum (and EVM-compatible chains) runtime module, \verb|eth:distro:sys|, which provides read and write access to blockchain data. This module can connect directly to WebSocket RPC endpoints or relay through other Kinode nodes, forming a potential chain of relays.
+The OS includes an Ethereum (and EVM-compatible chains) indexing runtime module, \verb|eth:distro:sys|, which provides read and write access to blockchain data. This module can connect directly to WebSocket RPC endpoints or relay through other Kinode nodes, forming a potential chain of relays.
 
 The module implements standard Ethereum JSON-RPC API methods, supporting operations such as querying block data, retrieving account balances, estimating gas costs, and sending transactions. Processes interact with this module through a request-response API, typically using a \verb|Provider| struct that encapsulates chain-specific details and request handling.
 
-Configuration is primarily done through an optional \verb|.eth-providers| JSON file in the node's home folder. This file allows users to specify their preferred RPC endpoints, relay nodes, and chain-specific settings. If the file is absent, the node uses default providers hardcoded for testnet or mainnet. The configuration can also be modified at runtime, enabling flexible provider management.
-
+Optional \verb|.eth_providers| and \verb|.eth_access_settings| JSON files in the node's home folder may be used to configure the module. The former allows users to specify their preferred RPC endpoints, relay nodes, and chain-specific settings, and the latter controls whether other nodes may use this node as a provider with potential allow/deny lists. The configuration can also be modified at runtime through the module's API, enabling flexible provider management.
 
 The module supports both one-time requests and subscriptions, particularly useful for monitoring real-time events specific log entries or kimap note keys. Subscriptions are managed through unique identifiers, allowing processes to filter and unsubscribe from event streams as needed.
 
-
-\verb|eth:distro:sys| also integrates with Kinode-specific functionalities, such as querying the KiMap contract, which is central to Kinode's naming and identity system. This allows processes to interact with Kinode-specific on-chain data seamlessly.
+\verb|eth:distro:sys| also integrates with Kinode-specific functionalities, such as querying the kimap contract, which is central to Kinode's naming and identity system. This allows processes to interact with Kinode-specific on-chain data seamlessly.
 
 \begin{verbatim}
 let node = namehash("node.foo.os");
 let (tba, owner, note) = provider.kimap_get(&node)?;
 \end{verbatim}
 
+The module acts as a relay and subscription manager for Ethereum JSON-RPC requests and responses. Processes may use helper functions and structs to format requests according to the Ethereum JSON-RPC specification\footnote{\url{https://ethereum.github.io/execution-apis/api-documentation/}}.
 
-Importantly, the module primarily acts as a relay and subscription manager for Ethereum JSON-RPC requests and responses. Most interactions with Ethereum nodes are handled directly by processes, using helper functions and structs from the \verb|process_lib| to format requests according to the Ethereum JSON-RPC specification\footnote{\url{https://ethereum.github.io/execution-apis/api-documentation/}}. The \verb|eth:distro:sys| module focuses on maintaining subscriptions, managing provider connections, and facilitating the routing of Ethereum data between Kinode nodes. This design allows processes to have direct control over their Ethereum interactions while benefiting from the module's network management capabilities, including the ability to relay requests through other nodes when direct RPC access is unavailable or undesirable.
+\verb|eth:distro:sys| handles maintenance of subscriptions, managing provider connections, and facilitating the routing of Ethereum data between Kinode instances, allowing processes to have direct control over their Ethereum interactions while benefiting from the module's network management capabilities, including the ability to relay requests through other nodes when direct RPC access is unavailable or not yet configured.
 
 This design facilitates the development of decentralized applications that can efficiently interact with global blockchain networks, even in constrained peer-to-peer environments. It allows for unique scaling possibilities:
 
@@ -742,6 +741,7 @@ This design facilitates the development of decentralized applications that can e
 \end{itemize}
 
 By providing this flexible and powerful interface to Ethereum and other EVM chains, Kinode OS enables developers to create robust blockchain-integrated applications while giving users control over their blockchain access points.
+
 \subsubsection{SQLite, KV-Store}
 \label{sec:osdbs}
 


### PR DESCRIPTION
More code/less code? I leaned toward less here to follow the rest of the whitepaper. 

going on about json rpc might be too trivial, the cooler part is having your app be installed by nodes that already have this configured so you as an app developer do not have to worry about it